### PR TITLE
Level two multiple menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ My thoughts on the given completion criteria
 
 - Create an object model for Menu and MenuItem classes
   - one-to-many relationship for Menu-to-MenuItem
+
+### Level 2: Multiple Menus
+
+- update the relationships so that multiple Menu instances can associate with multiple MenuItem and multiple MenuItem can associate with multiple Menu.
+- adding a Unique decorator to the MenuItem, added JoinTable to the owning Menu to connect MenuItem, and
+- database has not yet been set up, so unit test still reflect properties only
+  - interesting note: might be worth adding a multi column unique constraint to MenuItem. Currently, by making the name column unique, one restaurant may have ownership over all instances of a common item. For example, Red Lobster may have 'Chicken Wings', which would mean KFC could not. In this case a multi-column-unique-constraint may be beneficial to associate a restaurant id before name on the MenuItem table.

--- a/popMenuTypeOrm/src/data-source.ts
+++ b/popMenuTypeOrm/src/data-source.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { DataSource } from "typeorm";
 import { Menu } from "./entity/Menu";
 import { MenuItem } from "./entity/MenuItem";
+import { Restaurant } from "./entity/Restaurant";
 
 export const AppDataSource = new DataSource({
   type: "postgres",
@@ -12,7 +13,7 @@ export const AppDataSource = new DataSource({
   database: "popMenuTypeOrm",
   synchronize: true,
   logging: false,
-  entities: [Menu, MenuItem],
+  entities: [Restaurant, Menu, MenuItem],
   migrations: [],
   subscribers: [],
 });

--- a/popMenuTypeOrm/src/entity/Menu.ts
+++ b/popMenuTypeOrm/src/entity/Menu.ts
@@ -1,14 +1,20 @@
-import { Entity, OneToMany } from "typeorm";
+import { Entity, ManyToOne, OneToMany } from "typeorm";
 import { IdNameBase } from "./IdNameBase";
 import { MenuItem } from "./MenuItem";
+import { Restaurant } from "./Restaurant";
 
 /**
  * The Menu model.
  *
  * @OneToMany - a Menu may have multiple MenuItems
+ *
+ * @ManyToOne - many Menu may belong to one Restaurant
  */
 @Entity()
 export class Menu extends IdNameBase {
   @OneToMany(() => MenuItem, (menuItem) => menuItem.menu)
   menuItems: MenuItem[];
+
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.menus)
+  restaurant: Restaurant;
 }

--- a/popMenuTypeOrm/src/entity/Menu.ts
+++ b/popMenuTypeOrm/src/entity/Menu.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, OneToMany } from "typeorm";
+import { Entity, JoinTable, ManyToMany, ManyToOne } from "typeorm";
 import { IdNameBase } from "./IdNameBase";
 import { MenuItem } from "./MenuItem";
 import { Restaurant } from "./Restaurant";
@@ -6,13 +6,14 @@ import { Restaurant } from "./Restaurant";
 /**
  * The Menu model.
  *
- * @OneToMany - a Menu may have multiple MenuItems
+ * @ManyToMany - Menu may have multiple MenuItem and MenuItem may be on multiple Menus
  *
  * @ManyToOne - many Menu may belong to one Restaurant
  */
 @Entity()
 export class Menu extends IdNameBase {
-  @OneToMany(() => MenuItem, (menuItem) => menuItem.menu)
+  @ManyToMany(() => MenuItem, (menuItem) => menuItem.menus)
+  @JoinTable()
   menuItems: MenuItem[];
 
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.menus)

--- a/popMenuTypeOrm/src/entity/MenuItem.ts
+++ b/popMenuTypeOrm/src/entity/MenuItem.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne } from "typeorm";
+import { Column, Entity, ManyToOne, Unique } from "typeorm";
 import { IdNameBase } from "./IdNameBase";
 import { Menu } from "./Menu";
 
@@ -8,6 +8,7 @@ import { Menu } from "./Menu";
  * @ManyToOne - many MenuItem may belong to one Menu
  */
 @Entity()
+@Unique(["name"])
 export class MenuItem extends IdNameBase {
   @Column()
   description: string;

--- a/popMenuTypeOrm/src/entity/MenuItem.ts
+++ b/popMenuTypeOrm/src/entity/MenuItem.ts
@@ -5,7 +5,7 @@ import { Menu } from "./Menu";
 /**
  * The Menu Item model.
  *
- * @ManyToOne - a MenuItem may be on multiple Menus
+ * @ManyToOne - many MenuItem may belong to one Menu
  */
 @Entity()
 export class MenuItem extends IdNameBase {

--- a/popMenuTypeOrm/src/entity/MenuItem.ts
+++ b/popMenuTypeOrm/src/entity/MenuItem.ts
@@ -1,11 +1,11 @@
-import { Column, Entity, ManyToOne, Unique } from "typeorm";
+import { Column, Entity, ManyToMany, Unique } from "typeorm";
 import { IdNameBase } from "./IdNameBase";
 import { Menu } from "./Menu";
 
 /**
  * The Menu Item model.
  *
- * @ManyToOne - many MenuItem may belong to one Menu
+ * @ManyToMany - many MenuItem may belong to multiple Menu
  */
 @Entity()
 @Unique(["name"])
@@ -16,6 +16,6 @@ export class MenuItem extends IdNameBase {
   @Column("decimal", { scale: 2 })
   price: number;
 
-  @ManyToOne(() => Menu, (menu) => menu.menuItems)
-  menu: Menu;
+  @ManyToMany(() => Menu, (menu) => menu.menuItems)
+  menus: Menu[];
 }

--- a/popMenuTypeOrm/src/entity/Restaurant.ts
+++ b/popMenuTypeOrm/src/entity/Restaurant.ts
@@ -1,0 +1,14 @@
+import { Entity, OneToMany } from "typeorm";
+import { IdNameBase } from "./IdNameBase";
+import { Menu } from "./Menu";
+
+/**
+ * The Restaurant model.
+ *
+ * @OneToMany - a Restaurant may have multiple Menu
+ */
+@Entity()
+export class Restaurant extends IdNameBase {
+  @OneToMany(() => Menu, (menu) => menu.restaurant)
+  menus: Menu[];
+}

--- a/popMenuTypeOrm/tests/menuItem.test.ts
+++ b/popMenuTypeOrm/tests/menuItem.test.ts
@@ -21,8 +21,8 @@ describe("Menu class", () => {
   it("should create a menu relationship", () => {
     const menu = new Menu();
     const menuItem = new MenuItem();
-    menuItem.menu = menu;
+    menuItem.menus = [menu];
 
-    expect(menuItem.menu).toBe(menu);
+    expect(menuItem.menus[0]).toBe(menu);
   });
 });

--- a/popMenuTypeOrm/tests/restaurant.test.ts
+++ b/popMenuTypeOrm/tests/restaurant.test.ts
@@ -1,0 +1,14 @@
+import { Restaurant } from "../src/entity/Restaurant";
+
+describe("Restaurant class", () => {
+  it("should create a restaurant instance", () => {
+    const restaurant = new Restaurant();
+    expect(restaurant).toBeInstanceOf(Restaurant);
+  });
+
+  it("should set the name property", () => {
+    const restaurant = new Restaurant();
+    restaurant.name = "test restaurant name";
+    expect(restaurant.name).toBe("test restaurant name");
+  });
+});


### PR DESCRIPTION
- add Restaurant entity
- update the relationships so that multiple Menu instances can associate with multiple MenuItem and multiple MenuItem can associate with multiple Menu.
- adding a Unique decorator to the MenuItem, added JoinTable to the owning Menu to connect MenuItem, and
- database has not yet been set up, so unit test still reflect properties only